### PR TITLE
chore: run CI on Node.js v14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, '*']
+        node-version: [14.x, '*']
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "puppeteer": "^13.0.0"
   },
   "engines": {
-    "node": ">=12.13.0"
+    "node": ">=14"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is important because the minimum version of Node for Lighthouse v9.x is v14.x

Reference: https://github.com/GoogleChrome/lighthouse/releases/tag/v9.0.0

merging this should fix the error in #322