### PR TITLE
chore: update repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/netlify-labs/netlify-plugin-lighthouse.git"
+    "url": "git+https://github.com/netlify/netlify-plugin-lighthouse.git"
   },
   "bugs": {
-    "url": "https://github.com/netlify-labs/netlify-plugin-lighthouse/issues"
+    "url": "https://github.com/netlify/netlify-plugin-lighthouse/issues"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.0.0",


### PR DESCRIPTION
Since the repository was moved from github.com/netlify-labs/netlify-plugin-lighthouse to https://github.com/netlify/netlify-plugin-lighthouse we need to also update package.json to show the new URL going forward