### PR TITLE
chore: remove non-existent working directory from workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
       - run: npm publish
-        working-directory: plugin
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,5 +36,4 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         with:
           github-token: ${{ steps.get-token.outputs.token }}
-          package-json-dir: plugin
 


### PR DESCRIPTION
The working directory defined in the release workflow was an oversight and is not needed