### PR TITLE
fix: specify node version `>=14.15 <18`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, '*']
+        node-version: [17.x, '*']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [17.x, '*']
+        node-version: [16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "echo 'no op'"
 publish = "example"
 
 [build.environment]
-NODE_VERSION = "17.9.1"
+NODE_VERSION = "16.15.1"
 
 [[plugins]]
 package = "./src/index.js"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "echo 'no op'"
 publish = "example"
 
 [build.environment]
-NODE_VERSION = "16.15.1"
+NODE_VERSION = "17.19.1"
 
 [[plugins]]
 package = "./src/index.js"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "echo 'no op'"
 publish = "example"
 
 [build.environment]
-NODE_VERSION = "17.19.1"
+NODE_VERSION = "17.9.1"
 
 [[plugins]]
 package = "./src/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prettier": "^2.0.0"
       },
       "engines": {
-        "node": ">=16.15.1"
+        "node": ">=14.15 <18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "cypress": "^9.0.0",
         "eslint": "^7.0.0",
         "eslint-plugin-cypress": "^2.11.2",
-        "husky": "^8.0.0",
+        "husky": "^8.0.1",
         "jest": "^28.0.0",
         "netlify-plugin-cypress": "^2.2.0",
         "prettier": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@netlify/plugin-lighthouse",
-
   "version": "3.0.0",
   "description": "Netlify Plugin to run Lighthouse on each build",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "puppeteer": "^15.0.0"
   },
   "engines": {
-    "node": ">=16.15.1"
+    "node": ">=14.15 || <18"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@netlify/plugin-lighthouse",
+
   "version": "3.0.0",
   "description": "Netlify Plugin to run Lighthouse on each build",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "puppeteer": "^15.0.0"
   },
   "engines": {
-    "node": ">=14.15 || <18"
+    "node": ">=14.15 <18"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "cypress": "^9.0.0",
     "eslint": "^7.0.0",
     "eslint-plugin-cypress": "^2.11.2",
-    "husky": "^8.0.0",
+    "husky": "^8.0.1",
     "jest": "^28.0.0",
     "netlify-plugin-cypress": "^2.2.0",
     "prettier": "^2.0.0"


### PR DESCRIPTION
- Lighthouse v9 does not work with node v18
- This updates the node version in package.json to match anything between v14.15 and 18
- Updated tests to run on v17.9