### PR TITLE
feat: reduce summary sent to only id and score

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,11 +219,13 @@ const processResults = ({ data, errors }) => {
     return {
       summary: data
         .map(({ path, url, summary, shortSummary, report }) => {
-          const extraDataSummary = Object.assign(
-            {},
-            ...summary.map((item) => ({ [item.id]: item.score * 100 })),
-          );
-          const obj = { summary: extraDataSummary, report };
+          const obj = { 
+            summary: summary.reduce((acc, item) => {
+              acc[item.id] = item.score*100; 
+              return acc;
+            }, {}), 
+            report 
+          };
 
           if (path) {
             obj.path = path;

--- a/src/index.js
+++ b/src/index.js
@@ -219,12 +219,12 @@ const processResults = ({ data, errors }) => {
     return {
       summary: data
         .map(({ path, url, summary, shortSummary, report }) => {
-          const obj = { 
+          const obj = {
             summary: summary.reduce((acc, item) => {
-              acc[item.id] = item.score*100; 
+              acc[item.id] = item.score * 100;
               return acc;
-            }, {}), 
-            report 
+            }, {}),
+            report,
           };
 
           if (path) {

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,11 @@ const processResults = ({ data, errors }) => {
     return {
       summary: data
         .map(({ path, url, summary, shortSummary, report }) => {
-          const obj = { summary, report };
+          const extraDataSummary = Object.assign(
+            {},
+            ...summary.map((item) => ({ [item.id]: item.score * 100 })),
+          );
+          const obj = { summary: extraDataSummary, report };
 
           if (path) {
             obj.path = path;


### PR DESCRIPTION
To reduce the processing work to be done for this data, it will be neat to just send what we need. This only affects what we send as part of `extraData`

This basically changes:

```
[
    { title: 'Performance', score: 1, id: 'performance', threshold: 0.5 },
    { title: 'Accessibility', score: 1, id: 'accessibility' },
    { title: 'Best Practices', score: 1, id: 'best-practices' },
    { title: 'SEO', score: 0.91, id: 'seo' },
    { title: 'PWA', score: 0.3, id: 'pwa' }
]
```

to

```json
{   
  "performance": 100, "accessibility": 100, "best-practices": 100, "seo": 91,  "pwa": 30                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
}
```
