### PR TITLE
fix: account for missing summary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,13 +219,14 @@ const processResults = ({ data, errors }) => {
     return {
       summary: data
         .map(({ path, url, summary, shortSummary, report }) => {
-          const obj = {
-            summary: summary.reduce((acc, item) => {
+          const obj = { report };
+
+          if (summary) {
+            obj.summary = summary.reduce((acc, item) => {
               acc[item.id] = item.score * 100;
               return acc;
-            }, {}),
-            report,
-          };
+            }, {});
+          }
 
           if (path) {
             obj.path = path;


### PR DESCRIPTION
Fixes an error
```
 Cannot read properties of undefined (reading 'reduce')
 ```
 
closes https://github.com/netlify/netlify-plugin-lighthouse/issues/450