### PR TITLE
feat: Add support for theme matching and scroll reporting via `postMessage`

### DIFF
--- a/src/replacements.js
+++ b/src/replacements.js
@@ -44,7 +44,7 @@ const enablePostMessageCommunication = {
   </script></body>`,
 };
 
-const replacements = [forceThemeChecking, enablePostMessageCommunication];
+const replacements = [enablePostMessageCommunication];
 
 const makeReplacements = (str) => {
   return replacements.reduce((acc, { source, replacement }) => {

--- a/src/replacements.test.js
+++ b/src/replacements.test.js
@@ -3,7 +3,7 @@ const { enablePostMessageCommunication } = require('./replacements');
 describe('replacements', () => {
   it('should make enablePostMessageCommunication replacement', () => {
     const data = '</div></body></html>';
-    const replacedContent = enablePostMessageCommunication(data)
+    const replacedContent = enablePostMessageCommunication(data);
     expect(replacedContent).toContain('</div><script>');
     expect(replacedContent).toContain('</script></body></html>');
   });

--- a/src/replacements.test.js
+++ b/src/replacements.test.js
@@ -1,18 +1,10 @@
-const { makeReplacements } = require('./replacements');
+const { enablePostMessageCommunication } = require('./replacements');
 
 describe('replacements', () => {
-  it('should make forceThemeChecking replacement', () => {
-    const data = 'window.matchMedia("(prefers-color-scheme: dark)").matches';
-    const result = 'window.matchMedia("(prefers-color-scheme)").matches';
-    expect(makeReplacements(data)).toEqual(result);
-  });
-
-  it('should make enableQuerystringThemeCheck replacement', () => {
-    const data = 'prepended;const n=e.rootEl;appended';
-    expect(makeReplacements(data)).toContain('prepended;const n=e.rootEl;');
-    expect(makeReplacements(data)).toContain(
-      'URLSearchParams(window.location.search)',
-    );
-    expect(makeReplacements(data)).toContain('appended');
+  it('should make enablePostMessageCommunication replacement', () => {
+    const data = '</div></body></html>';
+    const replacedContent = enablePostMessageCommunication(data)
+    expect(replacedContent).toContain('</div><script>');
+    expect(replacedContent).toContain('</script></body></html>');
   });
 });

--- a/src/replacements.test.js
+++ b/src/replacements.test.js
@@ -1,9 +1,9 @@
-const { enablePostMessageCommunication } = require('./replacements');
+const { makeReplacements } = require('./replacements');
 
 describe('replacements', () => {
   it('should make enablePostMessageCommunication replacement', () => {
     const data = '</div></body></html>';
-    const replacedContent = enablePostMessageCommunication(data);
+    const replacedContent = makeReplacements(data);
     expect(replacedContent).toContain('</div><script>');
     expect(replacedContent).toContain('</script></body></html>');
   });


### PR DESCRIPTION
This PR removes the existing (but unused) functionality for reading a users theme preference via query parameter.

Instead, we will use `postMessage` to communicate cross-origin between the report and the App. We'll be sending a theme preference in one direction, and sending back a message when the scroll reaches the page bottom.

This approach has less flexibility than before, in that the theme switching now _only_ works within an iframe (which is fine for current needs). On the plus side, the injection does feel cleaner than the previous iteration as we're now appending a standalone script at the end, rather than injecting mid-function.