### PR TITLE
Add example showing multiple site paths support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ A Netlify plugin to generate a lighthouse report for every deploy
 
 ## Usage
 
-You can install this plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) or from the [Plugins directory](https://app.netlify.com/plugins).
+If you would like to run the Lighthouse build plugin for multiple site paths, such as for the site root path and a contact page, we recommend installing the build plugin manually in the `netlify.toml` file.
+
+### Install plugin through the Netlify UI
+
+You can install this plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) or from the [Plugins directory](https://app.netlify.com/plugins). 
+
+### Install plugin through the `netlify.toml` file
 
 You can also install it manually:
 
@@ -59,6 +65,23 @@ You can customize the behavior via the `audits` input:
     [plugins.inputs.audits.thresholds]
       performance = 0.8
 ```
+
+Example `netlify.toml` file that audits the site root path and a contact page:
+
+```
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+  
+  # Generate a Lighthouse report for the site's root path
+  [[plugins.inputs.audits]]
+  path = ""
+        
+  # Generate a Lighthouse report for the contact site path
+  [[plugins.inputs.audits]]
+  path = "contact"
+
+```
+
 
 The lighthouse report results are automatically printed to the **Deploy log** in the Netlify UI. For example:
 ```

--- a/README.md
+++ b/README.md
@@ -129,4 +129,6 @@ Some items of note:
 - The [Lighthouse Build Plugin](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) must be installed on your site(s) in order for these score visualizations to be displayed.
 - This Labs feature is currently only enabled at the user-level, so it will need to be enabled for each individual team member that wishes to see the Lighthouse scores displayed.
 
+Learn more in our official [Labs docs](https://docs.netlify.com/netlify-labs/experimental-features/lighthouse-visualization/).
+
 We have a lot planned for this feature and will be adding functionality regularly, but we'd also love to hear your thoughts. Please [share your feedback](https://netlify.qualtrics.com/jfe/form/SV_1NTbTSpvEi0UzWe) about this experimental feature and tell us what you think.


### PR DESCRIPTION
Just a small update here to ensure clarity on auditing multiple site paths and a link to the labs docs.

cc @MetalMatt-Netlify for awareness & review