### PR TITLE
fix: run replacements function before HTML minification

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,9 @@ const formatResults = ({ results, thresholds }) => {
     .map(({ title, score }) => `${title}: ${score * 100}`)
     .join(', ');
 
-  const report = minify(results.report, {
+  const formattedReport = makeReplacements(results.report);
+
+  const report = minify(formattedReport, {
     removeAttributeQuotes: true,
     collapseWhitespace: true,
     removeRedundantAttributes: true,
@@ -272,11 +274,8 @@ module.exports = {
           console.log({ results: summary });
         }
 
-        let formattedReport;
         if (report) {
-          formattedReport = makeReplacements(report);
-
-          const size = Buffer.byteLength(JSON.stringify(formattedReport));
+          const size = Buffer.byteLength(JSON.stringify(report));
           console.log(
             `Report collected: audited_uri: '${chalk.magenta(
               url || path,
@@ -292,7 +291,7 @@ module.exports = {
             url,
             summary,
             shortSummary,
-            report: formattedReport,
+            report,
           });
         }
       }


### PR DESCRIPTION
I recently merged a change to add `postMessage` functionality, inserting it in a `<script>`, before the closing `</body>` tag (v3.4.0).

What I didn't notice, is that we run HTML minification _before_ replacements are made, and there was no `</body>` left to match/replace (it is technically valid HTML to not have a closing `</body>` and `</html>`).

This meant the additional `<script>` is not currently being added. I had been testing against a standalone report which had not gone through the minifier. Previous replacements (now removed) had been working fine, as they were matching against strings which happened to not be changed during the process.

This PR moves the `makeReplacements` function call to before the minification, with the bonus effect that the replaced code is now also minified.