### PR TITLE
Adds score rounding to avoid floating point errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ const formatResults = ({ results, thresholds }) => {
   }));
 
   const shortSummary = categories
-    .map(({ title, score }) => `${title}: ${score * 100}`)
+    .map(({ title, score }) => `${title}: ${Math.round(score * 100)}`)
     .join(', ');
 
   const formattedReport = makeReplacements(results.report);
@@ -226,7 +226,7 @@ const processResults = ({ data, errors }) => {
 
           if (summary) {
             obj.summary = summary.reduce((acc, item) => {
-              acc[item.id] = item.score * 100;
+              acc[item.id] = Math.round(item.score * 100);
               return acc;
             }, {});
           }


### PR DESCRIPTION
Closes https://github.com/netlify/netlify-plugin-lighthouse/issues/441 by adding `Math.round` to the places we normalize the decimal scores to percentages.

This isn't urgent so doesn't need a specific release, it can go out with the next round of changes