### PR TITLE
Pass (selected) Lighthouse settings via netlify.toml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ AUDITS=[{"url":"https://www.example.com","thresholds":{"performance":0.5}},{"pat
 PUBLISH_DIR=FULL_PATH_TO_LOCAL_BUILD_DIRECTORY
 # JSON string of thresholds to enforce
 THRESHOLDS={"performance":0.9,"accessibility":0.9,"best-practices":0.9,"seo":0.9,"pwa":0.9}
+# SETTINGS
+SETTINGS={"locale":"en", "preset":"desktop"}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 reports
 cypress/videos
 cypress/screenshots
+coverage

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ We currently support the following settings which are passed directly to Lightho
   package = "@netlify/plugin-lighthouse"
 
   [[plugins.inputs.audits]]
-  formFactor = "desktop" # Either "mobile" (default), or "desktop"
-  locale = "es" # Any Lighthouse-supported locale to generate reports in a different language
+    formFactor = "desktop" # Either "mobile" (default), or "desktop"
+    locale = "es" # Any Lighthouse-supported locale to generate reports in a different language
 ```
 
 ## Running Locally

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We currently support the following settings, which are passed directly to Lighth
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
-  [[plugins.inputs.settings]]
+  [plugins.inputs.settings]
     preset = "desktop" # Optionally run Lighthouse using a desktop configuration
     locale = "es" # Any Lighthouse-supported locale, used to generate reports in a different language
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you would like to run the Lighthouse build plugin for multiple site paths, su
 
 ### Install plugin through the Netlify UI
 
-You can install this plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) or from the [Plugins directory](https://app.netlify.com/plugins). 
+You can install this plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) or from the [Plugins directory](https://app.netlify.com/plugins).
 
 ### Install plugin through the `netlify.toml` file
 
@@ -71,22 +71,22 @@ Example `netlify.toml` file that audits the site root path and a contact page:
 ```
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
-  
+
   # Generate a Lighthouse report for the site's root path
   [[plugins.inputs.audits]]
   path = ""
-        
+
   # Generate a Lighthouse report for the contact site path
   [[plugins.inputs.audits]]
   path = "contact"
 
 ```
 
-
 The lighthouse report results are automatically printed to the **Deploy log** in the Netlify UI. For example:
+
 ```
 2:35:07 PM: ────────────────────────────────────────────────────────────────
-2:35:07 PM:   2. onPostBuild command from @netlify/plugin-lighthouse        
+2:35:07 PM:   2. onPostBuild command from @netlify/plugin-lighthouse
 2:35:07 PM: ────────────────────────────────────────────────────────────────
 2:35:07 PM: ​
 2:35:07 PM: Serving and scanning site from directory dist
@@ -102,6 +102,17 @@ The lighthouse report results are automatically printed to the **Deploy log** in
 2:35:17 PM:     { title: 'Progressive Web App', score: 0.4, id: 'pwa' }
 2:35:17 PM:   ]
 2:35:17 PM: }
+```
+
+We currently support the following settings which are passed directly to Lighthouse:
+
+```
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  [[plugins.inputs.audits]]
+  formFactor = "desktop" # Either "mobile" (default), or "desktop"
+  locale = "es" # Any Lighthouse-supported locale to generate reports in a different language
 ```
 
 ## Running Locally
@@ -126,6 +137,7 @@ If you have multiple audits (directories, paths, etc) defined in your build, we 
 <img width="1400" alt="Deploy details with multiple audit Lighthouse results" src="https://user-images.githubusercontent.com/79875905/160019057-d29dffab-49f3-4fbf-a1ac-1f314e0cd837.png">
 
 Some items of note:
+
 - The [Lighthouse Build Plugin](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install) must be installed on your site(s) in order for these score visualizations to be displayed.
 - This Labs feature is currently only enabled at the user-level, so it will need to be enabled for each individual team member that wishes to see the Lighthouse scores displayed.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We currently support the following settings, which are passed directly to Lighth
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
-  [[plugins.inputs.audits]]
+  [[plugins.inputs.settings]]
     preset = "desktop" # Optionally run Lighthouse using a desktop configuration
     locale = "es" # Any Lighthouse-supported locale, used to generate reports in a different language
 ```

--- a/README.md
+++ b/README.md
@@ -104,15 +104,15 @@ The lighthouse report results are automatically printed to the **Deploy log** in
 2:35:17 PM: }
 ```
 
-We currently support the following settings which are passed directly to Lighthouse:
+We currently support the following settings, which are passed directly to Lighthouse:
 
 ```
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
   [[plugins.inputs.audits]]
-    formFactor = "desktop" # Either "mobile" (default), or "desktop"
-    locale = "es" # Any Lighthouse-supported locale to generate reports in a different language
+    preset = "desktop" # Optionally run Lighthouse using a desktop configuration
+    locale = "es" # Any Lighthouse-supported locale, used to generate reports in a different language
 ```
 
 ## Running Locally

--- a/manifest.yml
+++ b/manifest.yml
@@ -16,3 +16,7 @@ inputs:
   - name: audits
     required: false
     description: A list of audits to perform. Each list item is an object with either a url/path to scan and an optional thresholds mapping.
+
+  - name: settings
+    required: false
+    description: Lighthouse-specific settings, used to modify reporting criteria

--- a/src/index.js
+++ b/src/index.js
@@ -266,7 +266,7 @@ module.exports = {
         inputs,
       });
 
-      const settings = getSettings(inputs.settings);
+      const settings = getSettings(inputs?.settings);
 
       const allErrors = [];
       const data = [];

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 const fs = require('fs').promises;
 const minify = require('html-minifier').minify;
 const { getConfiguration } = require('./config');
+const { getSettings } = require('./settings');
 const { getBrowserPath, runLighthouse } = require('./lighthouse');
 const { makeReplacements } = require('./replacements');
 
@@ -136,14 +137,18 @@ const getUtils = ({ utils }) => {
   return { failBuild, show };
 };
 
-const runAudit = async ({ path, url, thresholds, output_path }) => {
+const runAudit = async ({ path, url, thresholds, output_path, settings }) => {
   try {
     const { server } = getServer({ serveDir: path, auditUrl: url });
     const browserPath = await getBrowserPath();
     const { error, results } = await new Promise((resolve) => {
       const instance = server.listen(async () => {
         try {
-          const results = await runLighthouse(browserPath, server.url);
+          const results = await runLighthouse(
+            browserPath,
+            server.url,
+            settings,
+          );
           resolve({ error: false, results });
         } catch (error) {
           resolve({ error });
@@ -261,6 +266,8 @@ module.exports = {
         inputs,
       });
 
+      const settings = getSettings(inputs.settings);
+
       const allErrors = [];
       const data = [];
       for (const { path, url, thresholds, output_path } of audits) {
@@ -269,6 +276,7 @@ module.exports = {
           url,
           thresholds,
           output_path,
+          settings,
         });
         if (summary) {
           console.log({ results: summary });

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -30,7 +30,7 @@ const getBrowserPath = async () => {
   return info.executablePath;
 };
 
-const runLighthouse = async (browserPath, url) => {
+const runLighthouse = async (browserPath, url, settings) => {
   let chrome;
   try {
     const logLevel = 'info';
@@ -45,11 +45,15 @@ const runLighthouse = async (browserPath, url) => {
       ],
       logLevel,
     });
-    const results = await lighthouse(url, {
-      port: chrome.port,
-      output: 'html',
-      logLevel,
-    });
+    const results = await lighthouse(
+      url,
+      {
+        port: chrome.port,
+        output: 'html',
+        logLevel,
+      },
+      settings,
+    );
     if (results.lhr.runtimeError) {
       throw new Error(results.lhr.runtimeError.message);
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,12 +1,18 @@
-const desktopOpts = require('lighthouse/lighthouse-core/config/desktop-config');
+const desktopConfig = require('lighthouse/lighthouse-core/config/desktop-config');
+const fullConfig = require('lighthouse/lighthouse-core/config/full-config');
 
-const getSettings = (settings) => {
-  console.log(111111, { settings });
-  if (!settings) return;
+const getSettings = (inputSettings) => {
+  if (!inputSettings) return;
 
-  if (settings.formFactor === 'desktop') {
-    return desktopOpts;
+  // Set a base-level config based on the formFactor (mobile/desktop)
+  const derivedSettings =
+    inputSettings.formFactor === 'desktop' ? desktopConfig : fullConfig;
+
+  if (inputSettings.locale) {
+    derivedSettings.settings.locale = inputSettings.locale;
   }
+
+  return derivedSettings;
 };
 
 module.exports = {

--- a/src/settings.js
+++ b/src/settings.js
@@ -15,9 +15,9 @@ const mergeSettingsSources = (inputSettings = {}) => {
     }
   }
 
-  // Shallow merge of input and env settings.
+  // Shallow merge of input and env settings, with input taking priority.
   // Review the need for a deep merge if/when more complex settings are added.
-  return Object.assign({}, inputSettings, envSettings);
+  return Object.assign({}, envSettings, inputSettings);
 };
 
 const getSettings = (inputSettings) => {

--- a/src/settings.js
+++ b/src/settings.js
@@ -11,6 +11,8 @@ const getSettings = (inputSettings) => {
   if (inputSettings.locale) {
     derivedSettings.settings.locale = inputSettings.locale;
   }
+  console.log('Settings specified in netlify.toml: ' + inputSettings);
+  console.log('Final derived settings: ' + derivedSettings);
 
   return derivedSettings;
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,18 +1,38 @@
 const desktopConfig = require('lighthouse/lighthouse-core/config/desktop-config');
 const fullConfig = require('lighthouse/lighthouse-core/config/full-config');
 
+/*
+ * Check for settings added in `.env` file and merge with input settings
+ * specified in `netlify.toml`
+ */
+const mergeSettingsSources = (inputSettings = {}) => {
+  let envSettings = {};
+  if (typeof process.env.SETTINGS === 'string') {
+    try {
+      envSettings = JSON.parse(process.env.SETTINGS);
+    } catch (e) {
+      throw new Error(`Invalid JSON for 'settings' input: ${e.message}`);
+    }
+  }
+
+  // Shallow merge of input and env settings.
+  // Review the need for a deep merge if/when more complex settings are added.
+  return Object.assign({}, inputSettings, envSettings);
+};
+
 const getSettings = (inputSettings) => {
-  if (!inputSettings || Object.keys(inputSettings).length === 0) return;
+  const settings = mergeSettingsSources(inputSettings);
+  if (Object.keys(settings).length === 0) return;
 
   // Set a base-level config based on the preset input value
   // (desktop is currently the only supported option)
   const derivedSettings =
-    inputSettings.preset === 'desktop' ? desktopConfig : fullConfig;
+    settings.preset === 'desktop' ? desktopConfig : fullConfig;
 
   // The following are added to the `settings` object of the selected base config
-
-  if (inputSettings.locale) {
-    derivedSettings.settings.locale = inputSettings.locale;
+  // We add individually to avoid passing anything unexpected to Lighthouse.
+  if (settings.locale) {
+    derivedSettings.settings.locale = settings.locale;
   }
 
   return derivedSettings;

--- a/src/settings.js
+++ b/src/settings.js
@@ -4,9 +4,10 @@ const fullConfig = require('lighthouse/lighthouse-core/config/full-config');
 const getSettings = (inputSettings) => {
   if (!inputSettings || Object.keys(inputSettings).length === 0) return;
 
-  // Set a base-level config based on the formFactor (mobile/desktop)
+  // Set a base-level config based on the preset input value
+  // (desktop is currently the only supported option)
   const derivedSettings =
-    inputSettings.formFactor === 'desktop' ? desktopConfig : fullConfig;
+    inputSettings.preset === 'desktop' ? desktopConfig : fullConfig;
 
   // The following are added to the `settings` object of the selected base config
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,17 +2,17 @@ const desktopConfig = require('lighthouse/lighthouse-core/config/desktop-config'
 const fullConfig = require('lighthouse/lighthouse-core/config/full-config');
 
 const getSettings = (inputSettings) => {
-  if (!inputSettings) return;
+  if (!inputSettings || Object.keys(inputSettings).length === 0) return;
 
   // Set a base-level config based on the formFactor (mobile/desktop)
   const derivedSettings =
     inputSettings.formFactor === 'desktop' ? desktopConfig : fullConfig;
 
+  // The following are added to the `settings` object of the selected base config
+
   if (inputSettings.locale) {
     derivedSettings.settings.locale = inputSettings.locale;
   }
-  console.log('Settings specified in netlify.toml: ' + inputSettings);
-  console.log('Final derived settings: ' + derivedSettings);
 
   return derivedSettings;
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,14 @@
+const desktopOpts = require('lighthouse/lighthouse-core/config/desktop-config');
+
+const getSettings = (settings) => {
+  console.log(111111, { settings });
+  if (!settings) return;
+
+  if (settings.formFactor === 'desktop') {
+    return desktopOpts;
+  }
+};
+
+module.exports = {
+  getSettings,
+};

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -1,0 +1,25 @@
+const { getSettings } = require('./settings');
+
+describe('replacements', () => {
+  it('should return nothing with no settings set', () => {
+    expect(getSettings()).toEqual(undefined);
+    expect(getSettings({})).toEqual(undefined);
+  });
+
+  it('should return a template config with formFactor set to mobile', () => {
+    const derivedSettings = getSettings({ formFactor: 'mobile' });
+    expect(derivedSettings.extends).toEqual('lighthouse:default');
+    expect(derivedSettings.settings.formFactor).toBeUndefined();
+  });
+
+  it('should return a template config with formFactor set to desktop', () => {
+    const derivedSettings = getSettings({ formFactor: 'desktop' });
+    expect(derivedSettings.extends).toEqual('lighthouse:default');
+    expect(derivedSettings.settings.formFactor).toEqual('desktop');
+  });
+
+  it('should add a locale if set', () => {
+    const derivedSettings = getSettings({ locale: 'es' });
+    expect(derivedSettings.settings.locale).toEqual('es');
+  });
+});

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -6,14 +6,8 @@ describe('replacements', () => {
     expect(getSettings({})).toEqual(undefined);
   });
 
-  it('should return a template config with formFactor set to mobile', () => {
-    const derivedSettings = getSettings({ formFactor: 'mobile' });
-    expect(derivedSettings.extends).toEqual('lighthouse:default');
-    expect(derivedSettings.settings.formFactor).toBeUndefined();
-  });
-
-  it('should return a template config with formFactor set to desktop', () => {
-    const derivedSettings = getSettings({ formFactor: 'desktop' });
+  it('should return a template config with preset set to desktop', () => {
+    const derivedSettings = getSettings({ preset: 'desktop' });
     expect(derivedSettings.extends).toEqual('lighthouse:default');
     expect(derivedSettings.settings.formFactor).toEqual('desktop');
   });

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -3,7 +3,6 @@ const { getSettings } = require('./settings');
 describe('replacements', () => {
   it('should return nothing with no settings set', () => {
     expect(getSettings()).toEqual(undefined);
-    expect(getSettings({})).toEqual(undefined);
   });
 
   it('should return a template config with preset set to desktop', () => {
@@ -15,5 +14,28 @@ describe('replacements', () => {
   it('should add a locale if set', () => {
     const derivedSettings = getSettings({ locale: 'es' });
     expect(derivedSettings.settings.locale).toEqual('es');
+  });
+
+  it('should use values from process.env.SETTINGS', () => {
+    process.env.SETTINGS = JSON.stringify({
+      preset: 'desktop',
+      locale: 'ar',
+    });
+    const derivedSettings = getSettings();
+    expect(derivedSettings.settings.formFactor).toEqual('desktop');
+    expect(derivedSettings.settings.locale).toEqual('ar');
+  });
+
+  it('should prefer values from input over process.env.SETTINGS', () => {
+    process.env.SETTINGS = JSON.stringify({
+      locale: 'ar',
+    });
+    const derivedSettings = getSettings({ locale: 'es' });
+    expect(derivedSettings.settings.locale).toEqual('es');
+  });
+
+  it('should error with incorrect syntax for process.env.SETTINGS', () => {
+    process.env.SETTINGS = 'not json';
+    expect(getSettings).toThrow(/Invalid JSON/);
   });
 });


### PR DESCRIPTION
Closes #387

This PR adds the ability to start passing custom Lighthouse settings, exposing some as optional `netlify.toml` fields.

Example usage (also added to the README):
```
[[plugins]]
  package = "@netlify/plugin-lighthouse"

  [plugins.inputs.settings]
    preset = "desktop" # Optionally run Lighthouse using a desktop configuration
    locale = "es" # Any Lighthouse-supported locale, used to generate reports in a different language
```

To start, the `preset` setting allows developers to opt-in to a desktop configuration (which are already set up by Lighthouse).

As a quick-win extra, I've also exposed the `locale` setting. This will allow devs to optionally specify the language used in the generated report. It also affects the reported scores within the Netlify UI. As with all `.toml` settings, this will apply at a site level, not per-user. Changing language of the reports will affect the output for all viewers of the deploy detail report.

Partial screenshot of a report generated using the above options:
<img width="803" alt="image" src="https://user-images.githubusercontent.com/720908/192785014-ec59befb-e069-4b54-8230-25ac803d74ac.png">
