### PR TITLE
feat: send reports on threshold failure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ const runAudit = async ({ path, url, thresholds, output_path, settings }) => {
       });
     });
 
-    if (error && Object.keys(error).length !== 0) {
+    if (error) {
       return { error };
     } else {
       const { summary, shortSummary, details, report, errors } = formatResults({
@@ -322,7 +322,7 @@ module.exports = {
       });
       extraInfo = extraData;
 
-      if (error) {
+      if (error && Object.keys(error).length !== 0) {
         throw error;
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ const processResults = ({ data, errors }) => {
 module.exports = {
   onPostBuild: async ({ constants, utils, inputs } = {}) => {
     const { failBuild, show } = getUtils({ utils });
-    let extraInfo = {};
+    let extraInfo = [];
 
     try {
       const { audits } = getConfiguration({
@@ -303,16 +303,15 @@ module.exports = {
 
         if (Array.isArray(errors) && errors.length > 0) {
           allErrors.push({ path, url, errors });
-        } else {
-          data.push({
-            path,
-            url,
-            summary,
-            shortSummary,
-            details,
-            report,
-          });
         }
+        data.push({
+          path,
+          url,
+          summary,
+          shortSummary,
+          details,
+          report,
+        });
       }
 
       const { error, summary, extraData } = processResults({
@@ -320,7 +319,7 @@ module.exports = {
         errors: allErrors,
         show,
       });
-      extraInfo = extraData;
+      extraInfo.push(...extraData);
 
       if (error && Object.keys(error).length !== 0) {
         throw error;

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ const runAudit = async ({ path, url, thresholds, output_path, settings }) => {
       });
     });
 
-    if (error) {
+    if (error && Object.keys(error).length !== 0) {
       return { error };
     } else {
       const { summary, shortSummary, details, report, errors } = formatResults({

--- a/src/index.js
+++ b/src/index.js
@@ -267,7 +267,7 @@ const processResults = ({ data, errors }) => {
 module.exports = {
   onPostBuild: async ({ constants, utils, inputs } = {}) => {
     const { failBuild, show } = getUtils({ utils });
-    let extraInfo = [];
+    let errorMetadata = [];
 
     try {
       const { audits } = getConfiguration({
@@ -319,7 +319,7 @@ module.exports = {
         errors: allErrors,
         show,
       });
-      extraInfo.push(...extraData);
+      errorMetadata.push(...extraData);
 
       if (error && Object.keys(error).length !== 0) {
         throw error;
@@ -330,10 +330,13 @@ module.exports = {
       if (error.details) {
         console.error(error.details);
         failBuild(`${chalk.red('Failed with error:\n')}${error.message}`, {
-          extraInfo,
+          errorMetadata,
         });
       } else {
-        failBuild(`${chalk.red('Failed with error:\n')}`, { error, extraInfo });
+        failBuild(`${chalk.red('Failed with error:\n')}`, {
+          error,
+          errorMetadata,
+        });
       }
     }
   },


### PR DESCRIPTION
Whenever a score threshold is not met, we fail the build. However, we currently do not send the report data once a threshold fails. This PR aims to fix that by ensuring we always send the report whether the threshold failed or not

tested with this RC build image - https://github.com/netlify/buildbot/pull/2291

Dependent on: https://github.com/netlify/buildbot/pull/2291

fixes https://github.com/netlify/pillar-workflow/issues/731