### PR TITLE
Reduce scope of 'installable' test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,7 @@ const formatResults = ({ results, thresholds }) => {
 
   // Pull some additional details to pass to App
   const { formFactor, locale } = results.lhr.configSettings;
-  const installable =
-    results.lhr.audits['installable-manifest'].score === 1 &&
-    results.lhr.audits['service-worker'].score === 1;
+  const installable = results.lhr.audits['installable-manifest'].score === 1;
   const details = { installable, formFactor, locale };
 
   const report = minify(formattedReport, {


### PR DESCRIPTION
Whilst implementing accessibility text for the PWA score in App, I noticed "being installable" only depends on one audit, not on multiple like the text description suggests. We're currently checking two – manifest and service worker.
https://github.com/GoogleChrome/lighthouse/blob/main/core/config/default-config.js#L657-L658

The audit grouping confirms having a service worker counts towards being "optimized", but not towards being "installable".
https://github.com/GoogleChrome/lighthouse/blob/main/core/config/default-config.js#L659-L660

This PR reduces the criteria for a report to be classed as installable, hopefully reducing the risk of false negatives