### PR TITLE
Remove node 17 from test workflow, add node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "puppeteer": "^18.0.0"
   },
   "engines": {
-    "node": ">=14.15 <18"
+    "node": ">=14.15 <19"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Testing on the (no longer supported) node 17 is blocking our latest Jest upgrade in https://github.com/netlify/netlify-plugin-lighthouse/pull/465

> Jest 29 doesn't support node 17, only 14.15, 16.10, 18+ [source](https://jestjs.io/docs/upgrading-to-jest29#compatibility)
>  As node 17 has passed its official end of life, I'm going to remove it from our workflow in favour of node 18

**Test plan**

Check this PR passes its node 18 tests, and didn't run any node 17 ones :)