### PR TITLE
Update Renovate config and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @netlify/pillar-dev-workflow
+*   @netlify/dev-workflow-pod-emea

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "semanticCommits": true,
   "dependencyDashboard": true,
   "schedule": ["9am every friday"],
-  "labels": ["dependency-update"],
+  "labels": ["area: dependencies"],
   "stabilityDays": 3,
   "prCreation": "not-pending"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,9 @@
   "extends": ["github>netlify/renovate-config:default"],
   "ignorePresets": [":prHourlyLimit2"],
   "semanticCommits": true,
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "schedule": ["9am every friday"],
+  "labels": ["dependency-update"],
+  "stabilityDays": 3,
+  "prCreation": "not-pending"
 }


### PR DESCRIPTION
Narrows the CODEOWNDERS scope to a single pod

Adds the following renovate options (borrowed from elsewhere in the Netlify Org):

- `schedule` – now runs at 9am on Fridays to add predictability
- `labels` – tags the PR as a dependency update
- `stabilityDays` – only bumps to a new version once it's been public for at least 3 days (avoids any immediate bugs, and matches the npm cutoff for removing a version)
- `prCreation` – Don't create PRs until all status checks have completed