### PR TITLE
Surface runtime errors in Deploy Log and Deploy Summary

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -33,47 +33,35 @@ const getError = (id, expected, categories, audits) => {
   return { message: categoryError, details: categoryAudits };
 };
 
-const formatShortSummary = ({ categories, runtimeError }) => {
-  if (runtimeError) {
-    return runtimeError.message;
-  }
+const formatShortSummary = (categories) => {
   return categories
     .map(({ title, score }) => `${title}: ${Math.round(score * 100)}`)
     .join(', ');
 };
 
 const formatResults = ({ results, thresholds }) => {
-  const hasScores = !results.lhr.runtimeError;
+  const runtimeError = results.lhr.runtimeError;
 
   const categories = Object.values(results.lhr.categories).map(
     ({ title, score, id, auditRefs }) => ({ title, score, id, auditRefs }),
   );
 
-  const categoriesBelowThreshold =
-    hasScores &&
-    Object.entries(thresholds).filter(([id, expected]) =>
-      belowThreshold(id, expected, categories),
-    );
+  const categoriesBelowThreshold = Object.entries(thresholds).filter(
+    ([id, expected]) => belowThreshold(id, expected, categories),
+  );
 
-  const errors =
-    hasScores &&
-    categoriesBelowThreshold.map(([id, expected]) =>
-      getError(id, expected, categories, results.lhr.audits),
-    );
+  const errors = categoriesBelowThreshold.map(([id, expected]) =>
+    getError(id, expected, categories, results.lhr.audits),
+  );
 
-  const summary =
-    hasScores &&
-    categories.map(({ title, score, id }) => ({
-      title,
-      score,
-      id,
-      ...(thresholds[id] ? { threshold: thresholds[id] } : {}),
-    }));
+  const summary = categories.map(({ title, score, id }) => ({
+    title,
+    score,
+    id,
+    ...(thresholds[id] ? { threshold: thresholds[id] } : {}),
+  }));
 
-  const shortSummary = formatShortSummary({
-    categories,
-    runtimeError: results.lhr.runtimeError,
-  });
+  const shortSummary = formatShortSummary(categories);
 
   const formattedReport = makeReplacements(results.report);
 
@@ -92,7 +80,7 @@ const formatResults = ({ results, thresholds }) => {
     minifyJS: true,
   });
 
-  return { summary, shortSummary, details, report, errors };
+  return { summary, shortSummary, details, report, errors, runtimeError };
 };
 
 module.exports = {

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,103 @@
+const chalk = require('chalk');
+const { minify } = require('html-minifier');
+const { makeReplacements } = require('./replacements');
+
+const belowThreshold = (id, expected, categories) => {
+  const category = categories.find((c) => c.id === id);
+  if (!category) {
+    console.warn(`Could not find category ${chalk.yellow(id)}`);
+  }
+  const actual = category ? category.score : Number.MAX_SAFE_INTEGER;
+  return actual < expected;
+};
+
+const getError = (id, expected, categories, audits) => {
+  const category = categories.find((c) => c.id === id);
+
+  const categoryError = `Expected category ${chalk.cyan(
+    category.title,
+  )} to be greater or equal to ${chalk.green(expected)} but got ${chalk.red(
+    category.score !== null ? category.score : 'unknown',
+  )}`;
+
+  const categoryAudits = category.auditRefs
+    .filter(({ weight, id }) => weight > 0 && audits[id].score < 1)
+    .map((ref) => {
+      const audit = audits[ref.id];
+      return `   '${chalk.cyan(
+        audit.title,
+      )}' received a score of ${chalk.yellow(audit.score)}`;
+    })
+    .join('\n');
+
+  return { message: categoryError, details: categoryAudits };
+};
+
+const formatShortSummary = ({ categories, runtimeError }) => {
+  if (runtimeError) {
+    return runtimeError.message;
+  }
+  return categories
+    .map(({ title, score }) => `${title}: ${Math.round(score * 100)}`)
+    .join(', ');
+};
+
+const formatResults = ({ results, thresholds }) => {
+  const hasScores = !results.lhr.runtimeError;
+
+  const categories = Object.values(results.lhr.categories).map(
+    ({ title, score, id, auditRefs }) => ({ title, score, id, auditRefs }),
+  );
+
+  const categoriesBelowThreshold =
+    hasScores &&
+    Object.entries(thresholds).filter(([id, expected]) =>
+      belowThreshold(id, expected, categories),
+    );
+
+  const errors =
+    hasScores &&
+    categoriesBelowThreshold.map(([id, expected]) =>
+      getError(id, expected, categories, results.lhr.audits),
+    );
+
+  const summary =
+    hasScores &&
+    categories.map(({ title, score, id }) => ({
+      title,
+      score,
+      id,
+      ...(thresholds[id] ? { threshold: thresholds[id] } : {}),
+    }));
+
+  const shortSummary = formatShortSummary({
+    categories,
+    runtimeError: results.lhr.runtimeError,
+  });
+
+  const formattedReport = makeReplacements(results.report);
+
+  // Pull some additional details to pass to App
+  const { formFactor, locale } = results.lhr.configSettings;
+  const installable = results.lhr.audits['installable-manifest']?.score === 1;
+  const details = { installable, formFactor, locale };
+
+  const report = minify(formattedReport, {
+    removeAttributeQuotes: true,
+    collapseWhitespace: true,
+    removeRedundantAttributes: true,
+    removeOptionalTags: true,
+    removeEmptyElements: true,
+    minifyCSS: true,
+    minifyJS: true,
+  });
+
+  return { summary, shortSummary, details, report, errors };
+};
+
+module.exports = {
+  belowThreshold,
+  getError,
+  formatShortSummary,
+  formatResults,
+};

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -106,24 +106,12 @@ describe('format', () => {
       { title: 'SEO', score: 0.7, id: 'seo' },
       { title: 'PWA', score: 0.6, id: 'pwa' },
     ];
-    const runtimeError = {
-      code: 'NO_FCP',
-      message:
-        'The page did not paint any content. Please ensure you keep the browser window in the foreground during the load and try again. (NO_FCP)',
-    };
 
     it('should return a shortSummary containing scores if available', () => {
-      const shortSummary = formatShortSummary({ categories });
+      const shortSummary = formatShortSummary(categories);
       expect(shortSummary).toEqual(
         'Performance: 100, Accessibility: 90, Best Practices: 80, SEO: 70, PWA: 60',
       );
-    });
-
-    it('should return a shortSummary error message', () => {
-      const shortSummary = formatShortSummary({
-        runtimeError,
-      });
-      expect(shortSummary).toEqual(runtimeError.message);
     });
   });
 

--- a/src/format.test.js
+++ b/src/format.test.js
@@ -1,0 +1,215 @@
+const {
+  belowThreshold,
+  getError,
+  formatShortSummary,
+  formatResults,
+} = require('./format');
+
+describe('format', () => {
+  const getCategories = ({ score }) => [
+    {
+      title: 'Performance',
+      score,
+      id: 'performance',
+      auditRefs: [
+        { weight: 1, id: 'is-crawlable' },
+        { weight: 1, id: 'robots-txt' },
+        { weight: 1, id: 'tap-targets' },
+      ],
+    },
+  ];
+  const audits = {
+    'is-crawlable': {
+      id: 'is-crawlable',
+      title: 'Page isn’t blocked from indexing',
+      description:
+        "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://web.dev/is-crawable/).",
+      score: 1,
+    },
+    'robots-txt': {
+      id: 'robots-txt',
+      title: 'robots.txt is valid',
+      description:
+        'If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed. [Learn more](https://web.dev/robots-txt/).',
+      score: 0,
+    },
+    'tap-targets': {
+      id: 'tap-targets',
+      title: 'Tap targets are sized appropriately',
+      description:
+        'Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://web.dev/tap-targets/).',
+      score: 0.5,
+    },
+  };
+
+  // Awkward formatting as the strings contain ANSI escape codes for colours.
+  const formattedError = {
+    details:
+      "   '\x1B[36mrobots.txt is valid\x1B[39m' received a score of \x1B[33m0\x1B[39m\n" +
+      "   '\x1B[36mTap targets are sized appropriately\x1B[39m' received a score of \x1B[33m0.5\x1B[39m",
+    message:
+      'Expected category \x1B[36mPerformance\x1B[39m to be greater or equal to \x1B[32m1\x1B[39m but got \x1B[31m0.5\x1B[39m',
+  };
+
+  it('returns an expected error message and list of details with valid score', () => {
+    const errorMessage = getError(
+      'performance',
+      1,
+      getCategories({ score: 0.5 }),
+      audits,
+    );
+    expect(errorMessage).toEqual(formattedError);
+  });
+
+  describe('belowThreshold', () => {
+    const categories = [
+      { title: 'Performance', score: 0.9, id: 'performance' },
+      { title: 'Accessibility', score: 0.8, id: 'accessibility' },
+    ];
+
+    it('returns false when the score is above the threshold', () => {
+      expect(belowThreshold('performance', 0.8, categories)).toBe(false);
+    });
+
+    it('returns false when the category is not found', () => {
+      console.warn = jest.fn();
+      const result = belowThreshold('seo', 0.8, categories);
+      expect(console.warn).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('returns true when the score is below the threshold', () => {
+      expect(belowThreshold('performance', 1, categories)).toBe(true);
+    });
+  });
+
+  describe('getError', () => {
+    it('returns an expected error message and list of details without valid score', () => {
+      const errorMessage = getError(
+        'performance',
+        1,
+        getCategories({ score: null }),
+        audits,
+      );
+      // Matching is awkward as the strings contain ANSI escape codes for colours.
+      expect(errorMessage.message).toContain(
+        'to be greater or equal to \x1B[32m1\x1B[39m but got \x1B[31munknown\x1B[39m',
+      );
+    });
+  });
+
+  describe('formatShortSummary', () => {
+    const categories = [
+      { title: 'Performance', score: 1, id: 'performance' },
+      { title: 'Accessibility', score: 0.9, id: 'accessibility' },
+      { title: 'Best Practices', score: 0.8, id: 'best-practices' },
+      { title: 'SEO', score: 0.7, id: 'seo' },
+      { title: 'PWA', score: 0.6, id: 'pwa' },
+    ];
+    const runtimeError = {
+      code: 'NO_FCP',
+      message:
+        'The page did not paint any content. Please ensure you keep the browser window in the foreground during the load and try again. (NO_FCP)',
+    };
+
+    it('should return a shortSummary containing scores if available', () => {
+      const shortSummary = formatShortSummary({ categories });
+      expect(shortSummary).toEqual(
+        'Performance: 100, Accessibility: 90, Best Practices: 80, SEO: 70, PWA: 60',
+      );
+    });
+
+    it('should return a shortSummary error message', () => {
+      const shortSummary = formatShortSummary({
+        runtimeError,
+      });
+      expect(shortSummary).toEqual(runtimeError.message);
+    });
+  });
+
+  describe('formatResults', () => {
+    const getResults = () => ({
+      lhr: {
+        lighthouseVersion: '9.6.3',
+        requestedUrl: 'http://localhost:5100/404.html',
+        finalUrl: 'http://localhost:5100/404.html',
+        audits,
+        configSettings: {},
+        categories: getCategories({ score: 0.5 }),
+      },
+      artifacts: {},
+      report: '<!doctype html>\n' + '<html lang="en">Hi</html>\n',
+    });
+
+    it('should return formatted results', () => {
+      expect(formatResults({ results: getResults(), thresholds: {} })).toEqual({
+        details: {
+          formFactor: undefined,
+          installable: false,
+          locale: undefined,
+        },
+        errors: [],
+        report: '<!doctype html><html lang=en>Hi',
+        shortSummary: 'Performance: 50',
+        summary: [{ id: 'performance', score: 0.5, title: 'Performance' }],
+      });
+    });
+
+    it('should return formatted results with passing thresholds', () => {
+      const thresholds = {
+        performance: 0.1,
+      };
+      const formattedResults = formatResults({
+        results: getResults(),
+        thresholds,
+      });
+      expect(formattedResults.errors).toEqual([]);
+      expect(formattedResults.summary).toEqual([
+        {
+          id: 'performance',
+          score: 0.5,
+          title: 'Performance',
+          threshold: 0.1,
+        },
+      ]);
+    });
+
+    it('should return formatted results with failing thresholds', () => {
+      const thresholds = {
+        performance: 1,
+      };
+      const formattedResults = formatResults({
+        results: getResults(),
+        thresholds,
+      });
+      expect(formattedResults.errors).toEqual([formattedError]);
+      expect(formattedResults.summary).toEqual([
+        {
+          id: 'performance',
+          score: 0.5,
+          title: 'Performance',
+          threshold: 1,
+        },
+      ]);
+    });
+
+    it('should use supplied config settings and data to populate `details`', () => {
+      const results = getResults();
+      results.lhr.configSettings = {
+        locale: 'es',
+        formFactor: 'desktop',
+      };
+      results.lhr.audits['installable-manifest'] = {
+        id: 'installable-manifest',
+        score: 1,
+      };
+
+      const formattedResults = formatResults({ results, thresholds: {} });
+      expect(formattedResults.details).toEqual({
+        formFactor: 'desktop',
+        installable: true,
+        locale: 'es',
+      });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,10 @@ const express = require('express');
 const compression = require('compression');
 const chalk = require('chalk');
 const fs = require('fs').promises;
-const minify = require('html-minifier').minify;
 const { getConfiguration } = require('./config');
 const { getSettings } = require('./settings');
 const { getBrowserPath, runLighthouse } = require('./lighthouse');
-const { makeReplacements } = require('./replacements');
+const { formatResults } = require('./format');
 
 const getServer = ({ serveDir, auditUrl }) => {
   if (auditUrl) {
@@ -45,81 +44,6 @@ const getServer = ({ serveDir, auditUrl }) => {
     url: `http://${host}:${port}`,
   };
   return { server };
-};
-
-const belowThreshold = (id, expected, categories) => {
-  const category = categories.find((c) => c.id === id);
-  if (!category) {
-    console.warn(`Could not find category ${chalk.yellow(id)}`);
-  }
-  const actual = category ? category.score : Number.MAX_SAFE_INTEGER;
-  return actual < expected;
-};
-
-const getError = (id, expected, categories, audits) => {
-  const category = categories.find((c) => c.id === id);
-
-  const categoryError = `Expected category ${chalk.cyan(
-    category.title,
-  )} to be greater or equal to ${chalk.green(expected)} but got ${chalk.red(
-    category.score !== null ? category.score : 'unknown',
-  )}`;
-
-  const categoryAudits = category.auditRefs
-    .filter(({ weight, id }) => weight > 0 && audits[id].score < 1)
-    .map((ref) => {
-      const audit = audits[ref.id];
-      return `   '${chalk.cyan(
-        audit.title,
-      )}' received a score of ${chalk.yellow(audit.score)}`;
-    })
-    .join('\n');
-
-  return { message: categoryError, details: categoryAudits };
-};
-
-const formatResults = ({ results, thresholds }) => {
-  const categories = Object.values(results.lhr.categories).map(
-    ({ title, score, id, auditRefs }) => ({ title, score, id, auditRefs }),
-  );
-
-  const categoriesBelowThreshold = Object.entries(thresholds).filter(
-    ([id, expected]) => belowThreshold(id, expected, categories),
-  );
-
-  const errors = categoriesBelowThreshold.map(([id, expected]) =>
-    getError(id, expected, categories, results.lhr.audits),
-  );
-
-  const summary = categories.map(({ title, score, id }) => ({
-    title,
-    score,
-    id,
-    ...(thresholds[id] ? { threshold: thresholds[id] } : {}),
-  }));
-
-  const shortSummary = categories
-    .map(({ title, score }) => `${title}: ${Math.round(score * 100)}`)
-    .join(', ');
-
-  const formattedReport = makeReplacements(results.report);
-
-  // Pull some additional details to pass to App
-  const { formFactor, locale } = results.lhr.configSettings;
-  const installable = results.lhr.audits['installable-manifest'].score === 1;
-  const details = { installable, formFactor, locale };
-
-  const report = minify(formattedReport, {
-    removeAttributeQuotes: true,
-    collapseWhitespace: true,
-    removeRedundantAttributes: true,
-    removeOptionalTags: true,
-    removeEmptyElements: true,
-    minifyCSS: true,
-    minifyJS: true,
-  });
-
-  return { summary, shortSummary, details, report, errors };
 };
 
 const persistResults = async ({ report, path }) => {
@@ -299,7 +223,9 @@ module.exports = {
           console.log(
             `Report collected: audited_uri: '${chalk.magenta(
               url || fullPath,
-            )}', html_report_size: ${chalk.magenta(size / 1024)} KiB`,
+            )}', html_report_size: ${chalk.magenta(
+              +(size / 1024).toFixed(2),
+            )} KiB`,
           );
         }
 

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -54,9 +54,6 @@ const runLighthouse = async (browserPath, url, settings) => {
       },
       settings,
     );
-    if (results.lhr.runtimeError) {
-      throw new Error(results.lhr.runtimeError.message);
-    }
     return results;
   } finally {
     if (chrome) {


### PR DESCRIPTION
Ensures any runtime errors reported by Lighthouse are passes around alongside the rest of the data. This is then surfaced in the Deploy Log (directly after the failing run) and as an item in the Deploy summary.

For Netlifiers, check out https://app.netlify.com/sites/with-lighthouse-plugin/deploys/6359368d902825000811cdfa#L695

**Deploy Summary**
Three runs, one of which failed:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/720908/198039668-73fa12dd-66fe-4f81-a08b-dfd35f344df5.png">

**Deploy Log**
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/720908/198039935-476354fe-77e0-4692-909b-3a7f7d2b31a9.png">

We use the error string provided by Lighthouse. I considered writing a few shorter versions to go in the Deploy Summary but [seeing the list of possible variations](https://github.com/GoogleChrome/lighthouse/blob/da3c865d698abc9365fa7bb087a08ce8c89b0a05/core/lib/lh-error.js#L221-L412) made me think again!

This PR also moves some "data formatting" functions to a standalone file and adds tests. In my first attempt, these were being modified to deal with the runtimeError, but I ended up undoing that. It seemed a shame to put the functions back, so I've kept them. I can split them into a new PR if easier.
