### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ Updates to `netlify.toml` will take effect for new builds.
     locale = "es" # generates Lighthouse reports in Español
 ```
 
+### Fail Builds Based on Score Thresholds
+
+By default, the Lighthouse will just report finding. To fail a build based on the findings, specify the inputs threasholds in your `netlify.toml` file. 
+
+```toml
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+  
+  [plugins.inputs.thresholds]
+    performance = 0.9
+```
+
 ### Run Lighthouse Locally
 
 Fork and clone this repo.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Updates to `netlify.toml` will take effect for new builds.
 
 ### Fail Builds Based on Score Thresholds
 
-By default, the Lighthouse will just report finding. To fail a build based on the findings, specify the inputs threasholds in your `netlify.toml` file. 
+By default, the Lighthouse plugin will report the findings in the deploy logs. To fail a build based on a specific score, specify the inputs thresholds in your `netlify.toml` file. Set the threshold based on `performance`, `accessibility`, `best-practices`, `seo`, or `pwa`.
 
 ```toml
 [[plugins]]


### PR DESCRIPTION
I did not see the configuration options for failing builds based on score thresholds in the README. Since this is the main documentation for the plugin, I took the liberty of making a pr for updating it. Probably should have called this a chore instead of a fix 😩 

![image](https://user-images.githubusercontent.com/45889730/199045714-969e3453-eb1f-49da-bb1f-a482923c2109.png)
