### PR TITLE
Change localhost port to avoid macOS collision

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6675,9 +6675,9 @@
       }
     },
     "node_modules/lighthouse": {
-      "version": "9.6.7",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-9.6.7.tgz",
-      "integrity": "sha512-5ve7eVnDjZPzdK4XG+fZPO3JG6xdyL6yvuMRawYYVLvBqafZel9fXeETtw1qsMg5cKP96lMQCaVP/OtuTHJmRw==",
+      "version": "9.6.8",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-9.6.8.tgz",
+      "integrity": "sha512-5aRSvnqazci8D2oE7GJM6C7IStvUuMVV+74cGyBuS4n4NCixsDd6+uJdX834XiInSfo+OuVbAJCX4Xu6d2+N9Q==",
       "dependencies": {
         "@sentry/node": "^6.17.4",
         "axe-core": "4.4.1",
@@ -15201,9 +15201,9 @@
       }
     },
     "lighthouse": {
-      "version": "9.6.7",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-9.6.7.tgz",
-      "integrity": "sha512-5ve7eVnDjZPzdK4XG+fZPO3JG6xdyL6yvuMRawYYVLvBqafZel9fXeETtw1qsMg5cKP96lMQCaVP/OtuTHJmRw==",
+      "version": "9.6.8",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-9.6.8.tgz",
+      "integrity": "sha512-5aRSvnqazci8D2oE7GJM6C7IStvUuMVV+74cGyBuS4n4NCixsDd6+uJdX834XiInSfo+OuVbAJCX4Xu6d2+N9Q==",
       "requires": {
         "@sentry/node": "^6.17.4",
         "axe-core": "4.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const getServer = ({ serveDir, auditUrl }) => {
   app.use(compression());
   app.use(express.static(serveDir));
 
-  const port = 5000;
+  const port = 5100;
   const host = 'localhost';
   const server = {
     listen: (func) => {


### PR DESCRIPTION
When testing the plugin locally, I've started getting 403 responses:
```
'Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Status code: 403)'
```

Turns out macOS uses port 5000 for Airplay. We should use a different one!

---

Googling tells me we can reclaim 5000 by disabling this system prefs option,  but as I've never used this, I'm guessing "on" is the default choice.

<img width="645" alt="image" src="https://user-images.githubusercontent.com/720908/202464603-7ba2c66d-9f2d-4e85-b91a-79928d4e52ef.png">
