### PR TITLE
Add some additional specs and set up jest coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,4 +3,5 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.+(ts|js)', '**/?(*.)+(spec|test).+(ts|js)'],
   setupFiles: ['<rootDir>/test/setup.js'],
   transform: {},
+  collectCoverageFrom: ['**/*.js'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@netlify/plugin-lighthouse",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "local": "node -e 'import(\"./src/index.js\").then(index => index.onPostBuild());'",
     "lint": "eslint 'src/**/*.js'",
     "format": "prettier --write 'src/**/*.js'",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collect-coverage",
     "format:ci": "prettier --check 'src/**/*.js'"
   },
   "keywords": [

--- a/src/lib/get-serve-path/get-serve-path.test.js
+++ b/src/lib/get-serve-path/get-serve-path.test.js
@@ -1,0 +1,17 @@
+import getServePath from '.';
+
+describe('getServePath', () => {
+  it('returns undefined for dir thats not a string', () => {
+    expect(getServePath(2)).toEqual({ serveDir: undefined });
+  });
+
+  it('returns undefined for subdir thats not a string', () => {
+    expect(getServePath(2, 2)).toEqual({ serveDir: undefined });
+  });
+
+  it('returns joined path for serveDir', () => {
+    expect(getServePath('example', 'path')).toEqual({
+      serveDir: 'example/path',
+    });
+  });
+});

--- a/src/lib/get-server/get-server.test.js
+++ b/src/lib/get-server/get-server.test.js
@@ -1,0 +1,64 @@
+jest.unstable_mockModule('chalk', () => {
+  return {
+    default: {
+      magenta: (m) => m,
+    },
+  };
+});
+
+const mockedExpress = () => ({
+  use: jest.fn(),
+  listen: jest.fn(),
+});
+const mockStatic = jest.fn();
+Object.defineProperty(mockedExpress, 'static', { value: mockStatic });
+
+jest.unstable_mockModule('express', () => {
+  return {
+    default: mockedExpress,
+  };
+});
+const getServer = (await import('.')).default;
+
+describe('getServer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a mock server if audit URL is defined', () => {
+    const mockListen = jest.fn();
+    console.log = jest.fn();
+
+    const { server } = getServer({ auditUrl: '/' });
+    expect(server.listen).toBeDefined();
+    server.listen(mockListen);
+    expect(mockListen).toHaveBeenCalled();
+    expect(console.log.mock.calls[0][0]).toEqual('Scanning url /');
+
+    expect(server.close).toBeDefined();
+    expect(server.close()).toBeUndefined();
+    expect(server.url).toEqual('/');
+  });
+
+  it('throws an error if no audit URL and no serveDir', () => {
+    expect(() => getServer({})).toThrow('Empty publish dir');
+  });
+
+  it('returns an express server if no audit URL and a serveDir', () => {
+    const { server } = getServer({ serveDir: 'dir' });
+    expect(mockStatic).toHaveBeenCalled();
+
+    // Check we log when we start serving directory
+    server.listen(jest.fn());
+    expect(console.log.mock.calls[0][0]).toEqual(
+      'Serving and scanning site from directory dir',
+    );
+
+    expect(server.url).toEqual('http://localhost:5100');
+
+    // Check close method closes the given instance
+    const close = jest.fn();
+    server.close({ close });
+    expect(close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This adds the jest coverage report when we run the tests locally, and adds a couple of new specs (bringing coverage for those particular files up to 100).

This contributes to internal tracking issue https://github.com/netlify/pillar-workflow/issues/1059 (but there's still more to do!)