### PR TITLE
Add node 19.x to the test matrix to support the current node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@netlify/plugin-lighthouse",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -31,7 +31,7 @@
         "prettier": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.15 <19"
+        "node": ">=14.15 <20"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "puppeteer": "^18.0.0"
   },
   "engines": {
-    "node": ">=14.15 <19"
+    "node": ">=14.15 <20"
   },
   "type": "module",
   "repository": {

--- a/src/lib/get-configuration/get-configuration.test.js
+++ b/src/lib/get-configuration/get-configuration.test.js
@@ -167,7 +167,9 @@ describe('config', () => {
       audits: [{}],
     };
 
-    expect(() => getConfiguration({ constants, inputs })).toThrow(/Invalid JSON for 'thresholds' input/);
+    expect(() => getConfiguration({ constants, inputs })).toThrow(
+      /Invalid JSON for 'thresholds' input/,
+    );
   });
 
   it('should throw error on invalid audits json input', () => {
@@ -177,7 +179,9 @@ describe('config', () => {
       audits: 'invalid_json',
     };
 
-    expect(() => getConfiguration({ constants, inputs })).toThrow(/Invalid JSON for 'thresholds' input/);
+    expect(() => getConfiguration({ constants, inputs })).toThrow(
+      /Invalid JSON for 'thresholds' input/,
+    );
   });
 
   it('should use specific audit output_path when configured', () => {

--- a/src/lib/get-configuration/get-configuration.test.js
+++ b/src/lib/get-configuration/get-configuration.test.js
@@ -11,6 +11,8 @@ jest.unstable_mockModule('chalk', () => {
 
 const getConfiguration = (await import('.')).default;
 
+const getNodeMajorVersion = () => parseInt(process.version.match(/v(\d+)/)[1]);
+
 describe('config', () => {
   beforeEach(() => {
     delete process.env.PUBLISH_DIR;
@@ -168,9 +170,13 @@ describe('config', () => {
     };
 
     expect(() => getConfiguration({ constants, inputs })).toThrow(
-      new Error(
-        `Invalid JSON for 'thresholds' input: Unexpected token i in JSON at position 0`,
-      ),
+      getNodeMajorVersion() >= 19
+        ? new Error(
+            "Invalid JSON for 'thresholds' input: Unexpected token 'i', \"invalid_json\" is not valid JSON",
+          )
+        : new Error(
+            `Invalid JSON for 'thresholds' input: Unexpected token i in JSON at position 0`,
+          ),
     );
   });
 
@@ -182,9 +188,13 @@ describe('config', () => {
     };
 
     expect(() => getConfiguration({ constants, inputs })).toThrow(
-      new Error(
-        `Invalid JSON for 'audits' input: Unexpected token i in JSON at position 0`,
-      ),
+      getNodeMajorVersion() >= 19
+        ? new Error(
+            "Invalid JSON for 'audits' input: Unexpected token 'i', \"invalid_json\" is not valid JSON",
+          )
+        : new Error(
+            `Invalid JSON for 'audits' input: Unexpected token i in JSON at position 0`,
+          ),
     );
   });
 

--- a/src/lib/get-configuration/get-configuration.test.js
+++ b/src/lib/get-configuration/get-configuration.test.js
@@ -11,8 +11,6 @@ jest.unstable_mockModule('chalk', () => {
 
 const getConfiguration = (await import('.')).default;
 
-const getNodeMajorVersion = () => parseInt(process.version.match(/v(\d+)/)[1]);
-
 describe('config', () => {
   beforeEach(() => {
     delete process.env.PUBLISH_DIR;
@@ -169,15 +167,7 @@ describe('config', () => {
       audits: [{}],
     };
 
-    expect(() => getConfiguration({ constants, inputs })).toThrow(
-      getNodeMajorVersion() >= 19
-        ? new Error(
-            "Invalid JSON for 'thresholds' input: Unexpected token 'i', \"invalid_json\" is not valid JSON",
-          )
-        : new Error(
-            `Invalid JSON for 'thresholds' input: Unexpected token i in JSON at position 0`,
-          ),
-    );
+    expect(() => getConfiguration({ constants, inputs })).toThrow(/Invalid JSON for 'thresholds' input/);
   });
 
   it('should throw error on invalid audits json input', () => {
@@ -187,15 +177,7 @@ describe('config', () => {
       audits: 'invalid_json',
     };
 
-    expect(() => getConfiguration({ constants, inputs })).toThrow(
-      getNodeMajorVersion() >= 19
-        ? new Error(
-            "Invalid JSON for 'audits' input: Unexpected token 'i', \"invalid_json\" is not valid JSON",
-          )
-        : new Error(
-            `Invalid JSON for 'audits' input: Unexpected token i in JSON at position 0`,
-          ),
-    );
+    expect(() => getConfiguration({ constants, inputs })).toThrow(/Invalid JSON for 'thresholds' input/);
   });
 
   it('should use specific audit output_path when configured', () => {

--- a/src/lib/get-configuration/get-configuration.test.js
+++ b/src/lib/get-configuration/get-configuration.test.js
@@ -180,7 +180,7 @@ describe('config', () => {
     };
 
     expect(() => getConfiguration({ constants, inputs })).toThrow(
-      /Invalid JSON for 'thresholds' input/,
+      /Invalid JSON for 'audits' input/,
     );
   });
 


### PR DESCRIPTION
This PR adds support for the current version of NodeJS (node 19).

The last "odd" version of NodeJS (17) was also supported and I think I'm not the only one that uses "current" NodeJS for development.
As far as I can tell NodeJS 19 works perfrectly fine with this plugin.