### PR TITLE
docs: fix audits sub-table array name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then add the plugin to your `netlify.toml` configuration file:
     pwa = 0.9
 
   # optional, deploy the lighthouse report to a path under your site
-  [plugins.inputs]
+  [plugins.inputs.audits]
     output_path = "reports/lighthouse.html"
 ```
 


### PR DESCRIPTION
Fixes the first example in the README, which has an incorrect sub-table array name - `[plugins.inputs]` instead of `[plugins.inputs.audits]` - that can lead to issues processing `netlify.toml` e.g. any header definitions in the file won't get parsed. 

Anyone copypasta-ing this first example (like, er, me) would likely end up with issues in their config.

The other examples in README look good; just the first that has issues.

Using the version from the README with no changes:

```toml
[[plugins]]
  package = "@netlify/plugin-lighthouse"

  # optional, fails build when a category is below a threshold
  [plugins.inputs.thresholds]
    performance = 0.9
    accessibility = 0.9
    best-practices = 0.9
    seo = 0.9
    pwa = 0.9

  # optional, deploy the lighthouse report to a path under your site
  [plugins.inputs]
    output_path = "reports/lighthouse.html"
```

...gives a log that look something like this:

```
8:32:16 PM: Starting post processing
8:32:16 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:16 PM: Post processing - HTML
8:32:16 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:16 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:16 PM: Post processing - header rules
8:32:16 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:17 PM: Post processing - redirect rules
8:32:17 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:17 PM: Post processing done
8:32:17 PM: Section completed: postprocessing
8:32:17 PM: Site is live ✨
```

Adding a valid `[[headers]]` section, like this:

```toml
[[headers]]
  for = "/*"
  [headers.values]
    Referrer-Policy = "strict-origin-when-cross-origin"

[[plugins]]
  package = "@netlify/plugin-lighthouse"

  # optional, fails build when a category is below a threshold
  [plugins.inputs.thresholds]
    performance = 0.9
    accessibility = 0.9
    best-practices = 0.9
    seo = 0.9
    pwa = 0.9

  # optional, deploy the lighthouse report to a path under your site
  [plugins.inputs]
    output_path = "reports/lighthouse.html"
```

...gives an identical log to the above:

```
8:32:58 PM: Starting post processing
8:32:58 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:58 PM: Post processing - HTML
8:32:58 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:59 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:59 PM: Post processing - header rules
8:32:59 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:59 PM: Post processing - redirect rules
8:32:59 PM: Incorrect TOML configuration format: Key inputs is already used as table key
8:32:59 PM: Post processing done
8:32:59 PM: Section completed: postprocessing
8:33:00 PM: Site is live ✨
```

...but also fails to parse the headers, saying "No header rules processed" in the Deploy summary.
