### PR TITLE
Adds tests for plugin event switching based on environment variable

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,27 @@
+import lighthousePlugin from './index.js';
+
+describe('lighthousePlugin plugin events', () => {
+  describe('onPostBuild', () => {
+    it('should return only the expected event function', async () => {
+      const events = lighthousePlugin();
+      expect(events).toEqual({
+        onPostBuild: expect.any(Function),
+      });
+    });
+  });
+
+  describe('onSuccess', () => {
+    beforeEach(() => {
+      process.env.RUN_ON_SUCCESS = 'true';
+    });
+    afterEach(() => {
+      delete process.env.RUN_ON_SUCCESS;
+    });
+    it('should return only the expected event function', async () => {
+      const events = lighthousePlugin();
+      expect(events).toEqual({
+        onSuccess: expect.any(Function),
+      });
+    });
+  });
+});


### PR DESCRIPTION
This test ensures `onPostBuild` is returned as the default plugin event, and `onSuccess` is returns if the `RUN_ON_SUCCESS` environment variable is present.