### PR TITLE
Support for ENV values in audit URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ You can customize the behavior via the `audits` input:
   [[plugins.inputs.audits]]
     url = "https://www.example.com"
 
+  # to audit an absolute url which depends on ENV value
+  [[plugins.inputs.audits]]
+    url = "https://${DEPLOY_PRIME_URL}/home"
+
     # you can specify thresholds per audit
     [plugins.inputs.audits.thresholds]
       performance = 0.8

--- a/src/lib/get-configuration/index.js
+++ b/src/lib/get-configuration/index.js
@@ -58,6 +58,13 @@ const getConfiguration = ({ constants, inputs, deployUrl } = {}) => {
     ];
   } else {
     auditConfigs = audits.map((a) => {
+      // parse ENV values in urls
+      if (a.url) {
+        a.url = a.url.replace(
+          /\${[A-Z_]+}/g,
+          (match) => process.env[match.substring(2, match.length-1)] ?? match
+        );
+      }
       return {
         ...a,
         thresholds: a.thresholds || thresholds,


### PR DESCRIPTION
This PR adds support for ENV values in audit URLs. 
It can be helpful when you cannot use local path but want to test current build. (e.g. next.js with SSR).
Env variable name should follow this regex `/[A-Z_]+/` and should be surrounded by `${ }` just like in JS string templates
Example:
```
  [[plugins.inputs.audits]]
    url = "https://${DEPLOY_PRIME_URL}/home"
```

