### PR TITLE
feat: Allow plugin to run onSuccess with toml setting or env var LIGHTHOUSE_RUN_ON_SUCCESS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "local": "node -e 'import(\"./src/index.js\").then(index => index.default()).then(events => events.onPostBuild());'",
-    "local-onsuccess": "RUN_ON_SUCCESS=true node -e 'import(\"./src/index.js\").then(index => index.default()).then(events => events.onSuccess());'",
+    "local-onsuccess": "LIGHTHOUSE_RUN_ON_SUCCESS=true node -e 'import(\"./src/index.js\").then(index => index.default()).then(events => events.onSuccess());'",
     "lint": "eslint 'src/**/*.js'",
     "format": "prettier --write 'src/**/*.js'",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --collect-coverage",

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,10 @@ import getUtils from './lib/get-utils/index.js';
 dotenv.config();
 
 export default function lighthousePlugin(inputs) {
-  // Run onPostBuild by default, unless RUN_ON_SUCCESS is set to true
+  // Run onPostBuild by default, unless LIGHTHOUSE_RUN_ON_SUCCESS env var is set to true, or run_on_success is specified in plugin inputs
   const defaultEvent =
-    inputs?.run_on_success === 'true' || process.env.RUN_ON_SUCCESS === 'true'
+    inputs?.run_on_success === 'true' ||
+    process.env.LIGHTHOUSE_RUN_ON_SUCCESS === 'true'
       ? 'onSuccess'
       : 'onPostBuild';
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -12,10 +12,10 @@ describe('lighthousePlugin plugin events', () => {
 
   describe('onSuccess', () => {
     beforeEach(() => {
-      process.env.RUN_ON_SUCCESS = 'true';
+      process.env.LIGHTHOUSE_RUN_ON_SUCCESS = 'true';
     });
     afterEach(() => {
-      delete process.env.RUN_ON_SUCCESS;
+      delete process.env.LIGHTHOUSE_RUN_ON_SUCCESS;
     });
     it('should return only the expected event function', async () => {
       const events = lighthousePlugin();


### PR DESCRIPTION
(went for a long PR title just for the sake of the changelog since we're going to cut a release with this)

Renames the env var to run on success to make this ready for experimental use.

Steps to validate:
- Using the plugin version at this branch, run a deploy for a site without adding any env variables/inputs for `run_on_success`. Plugin should run `onPostBuild` as before
- Set `run_on_success` to `'true'` in the site's `toml` file and deploy. Plugin should run on success and results should be shown in the UI when ready
- Remove the toml setting and set an environment variable for your site `LIGHTHOUSE_RUN_ON_SUCCESS='TRUE'`. Plugin should run on success and results should be shown in the UI when ready