### PR TITLE
fix(deps): Revert "chore(deps): update dependency netlify-plugin-cypress to ^2.2…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@netlify/plugin-lighthouse",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -16,7 +16,7 @@
         "express": "^4.17.1",
         "html-minifier": "^4.0.0",
         "lighthouse": "^9.6.3",
-        "puppeteer": "^18.0.0"
+        "puppeteer": "18.2.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.0.0",
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.27.4",
         "husky": "^8.0.1",
         "jest": "^29.0.0",
-        "netlify-plugin-cypress": "^2.2.0",
+        "netlify-plugin-cypress": "^2.2.1",
         "prettier": "^2.0.0"
       },
       "engines": {
@@ -8340,16 +8340,16 @@
       }
     },
     "node_modules/netlify-plugin-cypress": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.0.tgz",
-      "integrity": "sha512-J8dt12slBztXLdEH9XCBiEgkbJjM1RVMcHmJrnRFydh2y0lGtGEN5OmMeCKKZ7Jvv7rrxMvVcuvtHNi+D4dq2Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.1.tgz",
+      "integrity": "sha512-No93crt1+vaszMQ2UDWbXVvdBSwN1MQZff9cW8YrpA/er+PixjV2h0JbHgsRLUl/7Pe+NGjlcP/txQvvViK2zw==",
       "dev": true,
       "dependencies": {
         "common-tags": "1.8.0",
         "debug": "4.1.1",
         "got": "10.7.0",
         "local-web-server": "^4.2.1",
-        "puppeteer": "^7.0.1",
+        "puppeteer": "18.1.0",
         "ramda": "0.27.1"
       },
       "engines": {
@@ -8367,34 +8367,77 @@
       }
     },
     "node_modules/netlify-plugin-cypress/node_modules/devtools-protocol": {
-      "version": "0.0.847576",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.847576.tgz",
-      "integrity": "sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==",
+      "version": "0.0.1045489",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
+      "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ==",
+      "dev": true
+    },
+    "node_modules/netlify-plugin-cypress/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/netlify-plugin-cypress/node_modules/puppeteer": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-7.1.0.tgz",
-      "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
-      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.1.0.tgz",
+      "integrity": "sha512-2RCVWIF+pZOSfksWlQU0Hh6CeUT5NYt66CDDgRyuReu6EvBAk1y+/Q7DuzYNvGChSecGMb7QPN0hkxAa3guAog==",
+      "deprecated": "< 19.4.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.847576",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1045489",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.9.0"
       },
       "engines": {
-        "node": ">=10.18.1"
+        "node": ">=14.1.0"
+      }
+    },
+    "node_modules/netlify-plugin-cypress/node_modules/puppeteer/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/netlify-plugin-cypress/node_modules/ws": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/no-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "express": "^4.17.1",
         "html-minifier": "^4.0.0",
         "lighthouse": "^9.6.3",
-        "puppeteer": "18.2.1"
+        "puppeteer": "18.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.0.0",
@@ -9099,15 +9099,23 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.2.1.tgz",
-      "integrity": "sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.1.0.tgz",
+      "integrity": "sha512-2RCVWIF+pZOSfksWlQU0Hh6CeUT5NYt66CDDgRyuReu6EvBAk1y+/Q7DuzYNvGChSecGMb7QPN0hkxAa3guAog==",
+      "deprecated": "< 19.4.0 is no longer supported",
       "hasInstallScript": true,
       "dependencies": {
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1045489",
+        "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
-        "puppeteer-core": "18.2.1"
+        "rimraf": "3.0.2",
+        "tar-fs": "2.1.1",
+        "unbzip2-stream": "1.4.3",
+        "ws": "8.9.0"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -9161,26 +9169,6 @@
       "version": "0.0.1045489",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
       "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ=="
-    },
-    "node_modules/puppeteer/node_modules/puppeteer-core": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-18.2.1.tgz",
-      "integrity": "sha512-MRtTAZfQTluz3U2oU/X2VqVWPcR1+94nbA2V6ZrSZRVEwLqZ8eclZ551qGFQD/vD2PYqHJwWOW/fpC721uznVw==",
-      "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1045489",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.9.0"
-      },
-      "engines": {
-        "node": ">=14.1.0"
-      }
     },
     "node_modules/puppeteer/node_modules/ws": {
       "version": "8.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@netlify/plugin-lighthouse",
-      "version": "4.0.7",
+      "version": "4.0.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.27.4",
         "husky": "^8.0.1",
         "jest": "^29.0.0",
-        "netlify-plugin-cypress": "^2.2.1",
+        "netlify-plugin-cypress": "^2.2.0",
         "prettier": "^2.0.0"
       },
       "engines": {
@@ -8340,16 +8340,16 @@
       }
     },
     "node_modules/netlify-plugin-cypress": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.1.tgz",
-      "integrity": "sha512-No93crt1+vaszMQ2UDWbXVvdBSwN1MQZff9cW8YrpA/er+PixjV2h0JbHgsRLUl/7Pe+NGjlcP/txQvvViK2zw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.0.tgz",
+      "integrity": "sha512-J8dt12slBztXLdEH9XCBiEgkbJjM1RVMcHmJrnRFydh2y0lGtGEN5OmMeCKKZ7Jvv7rrxMvVcuvtHNi+D4dq2Q==",
       "dev": true,
       "dependencies": {
         "common-tags": "1.8.0",
         "debug": "4.1.1",
         "got": "10.7.0",
         "local-web-server": "^4.2.1",
-        "puppeteer": "18.1.0",
+        "puppeteer": "^7.0.1",
         "ramda": "0.27.1"
       },
       "engines": {
@@ -8367,77 +8367,34 @@
       }
     },
     "node_modules/netlify-plugin-cypress/node_modules/devtools-protocol": {
-      "version": "0.0.1045489",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
-      "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ==",
-      "dev": true
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "0.0.847576",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.847576.tgz",
+      "integrity": "sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==",
       "dev": true
     },
     "node_modules/netlify-plugin-cypress/node_modules/puppeteer": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.1.0.tgz",
-      "integrity": "sha512-2RCVWIF+pZOSfksWlQU0Hh6CeUT5NYt66CDDgRyuReu6EvBAk1y+/Q7DuzYNvGChSecGMb7QPN0hkxAa3guAog==",
-      "deprecated": "< 19.2.0 is no longer supported",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-7.1.0.tgz",
+      "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1045489",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.9.0"
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.847576",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       },
       "engines": {
-        "node": ">=14.1.0"
-      }
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/puppeteer/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=10.18.1"
       }
     },
     "node_modules/no-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.27.4",
         "husky": "^8.0.1",
         "jest": "^29.0.0",
-        "netlify-plugin-cypress": "^2.2.1",
+        "netlify-plugin-cypress": "2.2.0",
         "prettier": "^2.0.0"
       },
       "engines": {
@@ -8340,16 +8340,16 @@
       }
     },
     "node_modules/netlify-plugin-cypress": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.1.tgz",
-      "integrity": "sha512-No93crt1+vaszMQ2UDWbXVvdBSwN1MQZff9cW8YrpA/er+PixjV2h0JbHgsRLUl/7Pe+NGjlcP/txQvvViK2zw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/netlify-plugin-cypress/-/netlify-plugin-cypress-2.2.0.tgz",
+      "integrity": "sha512-J8dt12slBztXLdEH9XCBiEgkbJjM1RVMcHmJrnRFydh2y0lGtGEN5OmMeCKKZ7Jvv7rrxMvVcuvtHNi+D4dq2Q==",
       "dev": true,
       "dependencies": {
         "common-tags": "1.8.0",
         "debug": "4.1.1",
         "got": "10.7.0",
         "local-web-server": "^4.2.1",
-        "puppeteer": "18.1.0",
+        "puppeteer": "^7.0.1",
         "ramda": "0.27.1"
       },
       "engines": {
@@ -8367,77 +8367,34 @@
       }
     },
     "node_modules/netlify-plugin-cypress/node_modules/devtools-protocol": {
-      "version": "0.0.1045489",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
-      "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ==",
-      "dev": true
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "0.0.847576",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.847576.tgz",
+      "integrity": "sha512-0M8kobnSQE0Jmly7Mhbeq0W/PpZfnuK+WjN2ZRVPbGqYwCHCioAVp84H0TcLimgECcN5H976y5QiXMGBC9JKmg==",
       "dev": true
     },
     "node_modules/netlify-plugin-cypress/node_modules/puppeteer": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-18.1.0.tgz",
-      "integrity": "sha512-2RCVWIF+pZOSfksWlQU0Hh6CeUT5NYt66CDDgRyuReu6EvBAk1y+/Q7DuzYNvGChSecGMb7QPN0hkxAa3guAog==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-7.1.0.tgz",
+      "integrity": "sha512-lqOLzqCKdh7yUAHvK6LxgOpQrL8Bv1/jvS8MLDXxcNms2rlM3E8p/Wlwc7efbRZ0twxTzUeqjN5EqrTwxOwc9g==",
       "deprecated": "< 19.4.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1045489",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.9.0"
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.847576",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       },
       "engines": {
-        "node": ">=14.1.0"
-      }
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/puppeteer/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/netlify-plugin-cypress/node_modules/ws": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
-      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=10.18.1"
       }
     },
     "node_modules/no-case": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.27.4",
     "husky": "^8.0.1",
     "jest": "^29.0.0",
-    "netlify-plugin-cypress": "^2.2.1",
+    "netlify-plugin-cypress": "^2.2.0",
     "prettier": "^2.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "express": "^4.17.1",
     "html-minifier": "^4.0.0",
     "lighthouse": "^9.6.3",
-    "puppeteer": "^18.0.0"
+    "puppeteer": "18.2.1"
   },
   "engines": {
     "node": ">=14.15 <20"
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.27.4",
     "husky": "^8.0.1",
     "jest": "^29.0.0",
-    "netlify-plugin-cypress": "^2.2.0",
+    "netlify-plugin-cypress": "^2.2.1",
     "prettier": "^2.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.27.4",
     "husky": "^8.0.1",
     "jest": "^29.0.0",
-    "netlify-plugin-cypress": "^2.2.1",
+    "netlify-plugin-cypress": "2.2.0",
     "prettier": "^2.0.0"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "express": "^4.17.1",
     "html-minifier": "^4.0.0",
     "lighthouse": "^9.6.3",
-    "puppeteer": "18.2.1"
+    "puppeteer": "18.1.0"
   },
   "engines": {
     "node": ">=14.15 <20"


### PR DESCRIPTION
….1 (#553)"

This reverts commit 88e9ec5e4d332a4948042e8e0c5d5646fe1ada4a.

Resolves at least one instance reported in https://github.com/netlify/netlify-plugin-lighthouse/issues/548

We've received [reports from some users](https://github.com/netlify/netlify-plugin-lighthouse/issues/548) that plugin runs are returning `undefined` in some cases. I managed to reproduce with the [repo provided in the linked issue](https://github.com/reinier/reinierladan.nl/blob/main/netlify.toml) and with some additional logging saw that chromium wasn't being found - exactly similar to [the issues we had when trying to upgrade `puppeteer` to latest](https://github.com/netlify/netlify-plugin-lighthouse/pull/544).

The long and short of it is this cypress plugin upgrade also upgraded puppeteer to a version introducing those same issues again. I'm reverting the plugin bump until we resolve the puppeteer issue

**To test:**

- Using the version of the plugin at this branch, deploy a build
- When it completes, retry the same build (not clearing the cache)
- Both builds and any subsequent one should show lighthouse reports

**Follow ups**

I'll create a follow up issue to add some more error logging to make this easier to spot in future (at the moment the error doesn't seem to bubble up to the UI output, and nothing is logged)