### PR TITLE
fix: Fix chrome-launcher error preventing reports being generated

### DIFF
--- a/src/lib/run-audit-with-server/index.js
+++ b/src/lib/run-audit-with-server/index.js
@@ -55,6 +55,7 @@ const runAuditWithServer = async ({
       };
     }
   } catch (error) {
+    console.warn(error);
     return { error };
   }
 };

--- a/src/lighthouse.js
+++ b/src/lighthouse.js
@@ -40,7 +40,7 @@ export const runLighthouse = async (browserPath, url, settings) => {
     return results;
   } finally {
     if (chrome) {
-      await chrome.kill().catch(() => undefined);
+      await chrome.kill();
     }
   }
 };


### PR DESCRIPTION
Fixes #548 

This was kind of a weird one to investigate. Initially after having set some additional error logging, I noticed this output:

```
1:19:22 PM: Error: Could not find local browser
1:19:22 PM:     at getBrowserPath (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/lighthouse.js:10:11)
1:19:22 PM:     at async runAuditWithServer (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/lib/run-audit-with-server/index.js:19:25)
1:19:22 PM:     at async runEvent (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/lib/run-event/index.js:73:9)
1:19:22 PM:     at async onPostBuild (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/index.js:37:9)
1:19:22 PM:     at async Object.run (file:///opt/buildhome/node-deps/node_modules/@netlify/build/lib/plugins/child/run.js:14:5)
1:19:22 PM:     at async handleEvent (file:///opt/buildhome/node-deps/node_modules/@netlify/build/lib/plugins/child/main.js:28:42)
1:19:22 PM:     at async process.<anonymous> (file:///opt/buildhome/node-deps/node_modules/@netlify/build/lib/plugins/ipc.js:91:24)
```

This led me to believe something had triggered the puppeteer caching issues we've previously seen. However clearing the build cache and retrying led to a different error being logged out reliably:

```
2:01:18 PM: TypeError: Cannot read properties of undefined (reading 'catch')
2:01:18 PM:     at runLighthouse (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/lighthouse.js:43:26)
2:01:18 PM:     at processTicksAndRejections (node:internal/process/task_queues:96:5)
2:01:18 PM:     at async Server.<anonymous> (file:///opt/build/repo/node_modules/@netlify/plugin-lighthouse/src/lib/run-audit-with-server/index.js:25:27)
2:01:18 PM: 
2:01:18 PM: (@netlify/plugin-lighthouse onPostBuild completed in 10.9s)
```

This would appear to be related to this `chrome-launcher` PR which made the `kill()` method no longer return a promise: https://github.com/GoogleChrome/chrome-launcher/pull/269 

I'm still not 100% sure why some users/repos were being affected by this and not all 🤔 In any case, this feels like a good start and if there are lingering issues hopefully they'll be a bit easier to detect.

## Test steps

- I'd suggest using one of the two public repos linked in #548 to test this, as I wasn't able to reproduce on my own test site.
- Run some deploys against the version of the plugin at this branch (you might need to clear cache first time to make sure the right version is installed)
- Check reports are generated