### PR TITLE
fix: skip is-crawlable audit when running onSuccess against DEPLOY_URL

### DIFF
--- a/src/lib/get-settings/get-settings.test.js
+++ b/src/lib/get-settings/get-settings.test.js
@@ -1,8 +1,10 @@
 import getSettings from './index.js';
 
 describe('replacements', () => {
-  it('should return nothing with no settings set', () => {
-    expect(getSettings()).toEqual(undefined);
+  it('should return the default config with no settings set', () => {
+    const derivedSettings = getSettings();
+    expect(derivedSettings.extends).toEqual('lighthouse:default');
+    expect(derivedSettings.settings).toEqual({});
   });
 
   it('should return a template config with preset set to desktop', () => {

--- a/src/lib/get-settings/get-settings.test.js
+++ b/src/lib/get-settings/get-settings.test.js
@@ -34,11 +34,6 @@ describe('replacements', () => {
     expect(derivedSettings.settings.locale).toEqual('es');
   });
 
-  it('should add skipAudits if using a deployUrl', () => {
-    const derivedSettings = getSettings({ preset: 'desktop' }, true);
-    expect(derivedSettings.settings.skipAudits).toEqual(['is-crawlable']);
-  });
-
   it('should error with incorrect syntax for process.env.SETTINGS', () => {
     process.env.SETTINGS = 'not json';
     expect(getSettings).toThrow(/Invalid JSON/);

--- a/src/lib/get-settings/get-settings.test.js
+++ b/src/lib/get-settings/get-settings.test.js
@@ -36,6 +36,11 @@ describe('replacements', () => {
     expect(derivedSettings.settings.locale).toEqual('es');
   });
 
+  it('should skip is-crawlable audit when using deployUrl', () => {
+    const derivedSettings = getSettings({}, true);
+    expect(derivedSettings.settings.skipAudits).toEqual(['is-crawlable']);
+  });
+
   it('should error with incorrect syntax for process.env.SETTINGS', () => {
     process.env.SETTINGS = 'not json';
     expect(getSettings).toThrow(/Invalid JSON/);

--- a/src/lib/get-settings/get-settings.test.js
+++ b/src/lib/get-settings/get-settings.test.js
@@ -34,6 +34,11 @@ describe('replacements', () => {
     expect(derivedSettings.settings.locale).toEqual('es');
   });
 
+  it('should add skipAudits if using a deployUrl', () => {
+    const derivedSettings = getSettings({ preset: 'desktop' }, true);
+    expect(derivedSettings.settings.skipAudits).toEqual(['seo/is-crawlable']);
+  });
+
   it('should error with incorrect syntax for process.env.SETTINGS', () => {
     process.env.SETTINGS = 'not json';
     expect(getSettings).toThrow(/Invalid JSON/);

--- a/src/lib/get-settings/get-settings.test.js
+++ b/src/lib/get-settings/get-settings.test.js
@@ -36,7 +36,7 @@ describe('replacements', () => {
 
   it('should add skipAudits if using a deployUrl', () => {
     const derivedSettings = getSettings({ preset: 'desktop' }, true);
-    expect(derivedSettings.settings.skipAudits).toEqual(['seo/is-crawlable']);
+    expect(derivedSettings.settings.skipAudits).toEqual(['is-crawlable']);
   });
 
   it('should error with incorrect syntax for process.env.SETTINGS', () => {

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -22,7 +22,11 @@ const mergeSettingsSources = (inputSettings = {}) => {
 
 const getSettings = (inputSettings, isUsingDeployUrl) => {
   const settings = mergeSettingsSources(inputSettings);
-  if (Object.keys(settings).length === 0) return;
+  if (Object.keys(settings).length === 0) {
+    return isUsingDeployUrl
+      ? undefined
+      : { settings: { skipAudits: ['is-crawlable'] } };
+  }
 
   // Set a base-level config based on the preset input value
   // (desktop is currently the only supported option)

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -22,7 +22,7 @@ const mergeSettingsSources = (inputSettings = {}) => {
 
 const getSettings = (inputSettings, isUsingDeployUrl) => {
   const settings = mergeSettingsSources(inputSettings);
-  if (Object.keys(settings).length === 0) return;
+  // if (Object.keys(settings).length === 0) return;
 
   // Set a base-level config based on the preset input value
   // (desktop is currently the only supported option)

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -22,11 +22,7 @@ const mergeSettingsSources = (inputSettings = {}) => {
 
 const getSettings = (inputSettings, isUsingDeployUrl) => {
   const settings = mergeSettingsSources(inputSettings);
-  if (Object.keys(settings).length === 0) {
-    return isUsingDeployUrl
-      ? undefined
-      : { settings: { skipAudits: ['is-crawlable'] } };
-  }
+  if (Object.keys(settings).length === 0) return;
 
   // Set a base-level config based on the preset input value
   // (desktop is currently the only supported option)

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -22,7 +22,6 @@ const mergeSettingsSources = (inputSettings = {}) => {
 
 const getSettings = (inputSettings, isUsingDeployUrl) => {
   const settings = mergeSettingsSources(inputSettings);
-  // if (Object.keys(settings).length === 0) return;
 
   // Set a base-level config based on the preset input value
   // (desktop is currently the only supported option)

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -20,7 +20,7 @@ const mergeSettingsSources = (inputSettings = {}) => {
   return Object.assign({}, envSettings, inputSettings);
 };
 
-const getSettings = (inputSettings) => {
+const getSettings = (inputSettings, isUsingDeployUrl) => {
   const settings = mergeSettingsSources(inputSettings);
   if (Object.keys(settings).length === 0) return;
 
@@ -33,6 +33,12 @@ const getSettings = (inputSettings) => {
   // We add individually to avoid passing anything unexpected to Lighthouse.
   if (settings.locale) {
     derivedSettings.settings.locale = settings.locale;
+  }
+
+  // If we are running against the Netlify deploy URL, the injected x-robots-tag will always cause the audit to fail,
+  // likely producing a false positive, so we skip in this case
+  if (isUsingDeployUrl) {
+    derivedSettings.settings.skipAudits = ['seo/is-crawlable'];
   }
 
   return derivedSettings;

--- a/src/lib/get-settings/index.js
+++ b/src/lib/get-settings/index.js
@@ -38,7 +38,7 @@ const getSettings = (inputSettings, isUsingDeployUrl) => {
   // If we are running against the Netlify deploy URL, the injected x-robots-tag will always cause the audit to fail,
   // likely producing a false positive, so we skip in this case
   if (isUsingDeployUrl) {
-    derivedSettings.settings.skipAudits = ['seo/is-crawlable'];
+    derivedSettings.settings.skipAudits = ['is-crawlable'];
   }
 
   return derivedSettings;

--- a/src/lib/run-audit-with-url/index.js
+++ b/src/lib/run-audit-with-url/index.js
@@ -12,14 +12,8 @@ const runAuditWithUrl = async ({
 
     const getResults = async () => {
       const fullPath = path ? `${url}/${path}` : url;
-      console.log('Running lighthouse with settings', {
-        ...settings,
-        skipAudits: ['is-crawlable'],
-      });
-      const results = await runLighthouse(browserPath, fullPath, {
-        ...settings,
-        skipAudits: ['is-crawlable'],
-      });
+      console.log('Running lighthouse with settings', settings);
+      const results = await runLighthouse(browserPath, fullPath, settings);
 
       try {
         return { results };

--- a/src/lib/run-audit-with-url/index.js
+++ b/src/lib/run-audit-with-url/index.js
@@ -7,7 +7,14 @@ const runAuditWithUrl = async ({ path = '', url, thresholds, settings }) => {
 
     const getResults = async () => {
       const fullPath = path ? `${url}/${path}` : url;
-      const results = await runLighthouse(browserPath, fullPath, settings);
+      console.log('Running lighthouse with settings', {
+        ...settings,
+        skipAudits: ['is-crawlable'],
+      });
+      const results = await runLighthouse(browserPath, fullPath, {
+        ...settings,
+        skipAudits: ['is-crawlable'],
+      });
 
       try {
         return { results };

--- a/src/lib/run-audit-with-url/index.js
+++ b/src/lib/run-audit-with-url/index.js
@@ -1,18 +1,12 @@
 import { formatResults } from '../../format.js';
 import { runLighthouse, getBrowserPath } from '../../run-lighthouse.js';
 
-const runAuditWithUrl = async ({
-  path = '',
-  url,
-  thresholds,
-  settings = {},
-}) => {
+const runAuditWithUrl = async ({ path = '', url, thresholds, settings }) => {
   try {
     const browserPath = await getBrowserPath();
 
     const getResults = async () => {
       const fullPath = path ? `${url}/${path}` : url;
-      console.log('Running lighthouse with settings', settings);
       const results = await runLighthouse(browserPath, fullPath, settings);
 
       try {

--- a/src/lib/run-audit-with-url/index.js
+++ b/src/lib/run-audit-with-url/index.js
@@ -1,7 +1,12 @@
 import { formatResults } from '../../format.js';
 import { runLighthouse, getBrowserPath } from '../../run-lighthouse.js';
 
-const runAuditWithUrl = async ({ path = '', url, thresholds, settings }) => {
+const runAuditWithUrl = async ({
+  path = '',
+  url,
+  thresholds,
+  settings = {},
+}) => {
   try {
     const browserPath = await getBrowserPath();
 

--- a/src/lib/run-event/index.js
+++ b/src/lib/run-event/index.js
@@ -49,8 +49,6 @@ const runEvent = async ({
   try {
     const settings = getSettings(inputs?.settings, isOnSuccess);
 
-    console.log('Configured settings:', settings);
-
     const allErrors = [];
     const data = [];
 

--- a/src/lib/run-event/index.js
+++ b/src/lib/run-event/index.js
@@ -47,7 +47,7 @@ const runEvent = async ({
   let errorMetadata = [];
 
   try {
-    const settings = getSettings(inputs?.settings);
+    const settings = getSettings(inputs?.settings, isOnSuccess);
 
     const allErrors = [];
     const data = [];

--- a/src/lib/run-event/index.js
+++ b/src/lib/run-event/index.js
@@ -49,6 +49,8 @@ const runEvent = async ({
   try {
     const settings = getSettings(inputs?.settings, isOnSuccess);
 
+    console.log('Configured settings:', settings);
+
     const allErrors = [];
     const data = [];
 


### PR DESCRIPTION
When we run onSuccess we use the `DEPLOY_URL` i.e. the permalink of the deploy. These deploys have `x-robots-tag: noindex` configured to stop bots from crawling deploy permalinks vs the main production site URL. This means we almost always receive a false positive for the lighthouse `is-crawlable` rule.

This PR skips that particular audit when running against the deploy url.

**To test:**

- You could install the branch version of this plugin on a site and observe the difference in behaviour, but I did prepare an example 😄 
- [This deploy is made with the latest fix](https://app.netlify.com/sites/suzanne-lighthouse-test/deploys/6716572fb3a7510009cc7902) - observe that the SEO report does not include any failure for allowing crawling
![](https://github.com/user-attachments/assets/2f6379c6-88e7-4b15-9cd9-cec08df811c8)



- [This deploy was made before the fix](https://app.netlify.com/sites/suzanne-lighthouse-test/deploys/67163c57fe97a50008941847) - notice that the SEO score is lower, and the crawling rule is highlighted in the report
![](https://github.com/user-attachments/assets/aa64cad7-98dd-449b-9972-dd77d853c61a)
